### PR TITLE
Add synthesized url to debug log

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ The [ServiceConfiguration](https://github.com/pelias/microservice-wrapper/blob/m
 | `timeout` | no | `250` | the number of milliseconds a request should wait for a server response before timing out |
 | `retries` | no | `3` | the number of retries to attempt before returning an error |
 
+Requests are logged at the `debug` level when enabled in [pelias-config](https://github.com/pelias/config).
+
 ### Example
 
 ```javascript

--- a/service.js
+++ b/service.js
@@ -49,6 +49,11 @@ module.exports = function setup(serviceConfig) {
 
     if (do_not_track) {
       headers.dnt = '1';
+      logger.debug(`${serviceConfig.getName()}: ${serviceConfig.getBaseUrl()}`);
+
+    } else {
+      logger.debug(`${serviceConfig.getName()}: ${synthesizeUrl(serviceConfig, req)}`);
+
     }
 
     request


### PR DESCRIPTION
Logs the request-to-be-made at the `debug` log level (sanitized when do-not-track is enabled).  