### PR TITLE
Use HTTP keep-alives

### DIFF
--- a/service.js
+++ b/service.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const http = require('http');
 const request = require('superagent');
 const _ = require('lodash');
 
@@ -47,6 +48,12 @@ module.exports = function setup(serviceConfig) {
   }
 
   logger.info(`using ${serviceConfig.getName()} service at ${serviceConfig.getBaseUrl()}`);
+
+  // create one HTTP agent with keep alives enabled per service instance
+  const agent = new http.Agent({
+    keepAlive: true
+  });
+
   return (req, res, callback) => {
     // only req was passed in so treat res as callback
     if (_.isUndefined(callback)) {
@@ -74,6 +81,7 @@ module.exports = function setup(serviceConfig) {
       .set(headers)
       .timeout(serviceConfig.getTimeout())
       .retry(serviceConfig.getRetries())
+      .agent(agent)
       .accept('json')
       .query(serviceConfig.getParameters(req, res))
       .on('error', (err) => {


### PR DESCRIPTION
This prevents the overhead and latency of creating a new connection for each request, which is critical to performance when there's a high volume of network traffic. It should at least marginally improve the
performance of all our services.

fixes https://github.com/pelias/microservice-wrapper/issues/12