### PR TITLE
Use carat ranges for all Pelias Dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   ],
   "devDependencies": {
     "express": "^4.15.2",
-    "pelias-mock-logger": "1.3.0",
+    "pelias-mock-logger": "^1.3.0",
     "proxyquire": "^2.0.0",
     "semantic-release": "^15.4.1",
     "tap-dot": "^1.0.5",


### PR DESCRIPTION
The overhead of having to merge a Greenkeeper PR for every single change to
every single repository (which leads to cascading PRs) is too much.

Connects https://github.com/pelias/pelias/issues/366