### PR TITLE
chore(test): Use dedicated test script to catch errors

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# run tests with pipefail to avoid false passes
+# see https://github.com/pelias/pelias/issues/744
+set -euo pipefail
+
+node test/test | npx tap-dot

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Module that provides a convenience wrapper around HTTP GET microservices",
   "main": "index.js",
   "scripts": {
-    "test": "node test/test | tap-dot",
+    "test": "./bin/test",
     "lint": "jshint .",
     "travis": "npm test",
     "validate": "npm ls"


### PR DESCRIPTION
The way we were running our unit tests does not catch fatal errors in
the unit test run, even though they return non-zero status codes.

By using a dedicated script to run the tests, with the `pipefail`
option, we can catch them.

Connects https://github.com/pelias/pelias/issues/744