### PR TITLE
chore(tests): Add explicit ends to base level tests

### DIFF
--- a/test/ServiceConfiguration.js
+++ b/test/ServiceConfiguration.js
@@ -89,5 +89,6 @@ tape('ServiceConfiguration tests', (test) => {
     t.end();
 
   });
+  test.end();
 
 });

--- a/test/index.js
+++ b/test/index.js
@@ -8,4 +8,5 @@ tape('index tests', (test) => {
     t.equals(typeof index.ServiceConfiguration, 'function');
     t.end();
   });
+  test.end();
 });

--- a/test/service.js
+++ b/test/service.js
@@ -19,6 +19,8 @@ tape('service tests', (test) => {
     t.end();
   });
 
+  test.end();
+
 });
 
 tape('conforms_to tests', (test) => {
@@ -31,6 +33,7 @@ tape('conforms_to tests', (test) => {
 
   });
 
+  test.end();
 });
 
 tape('request logging', (test) => {
@@ -123,6 +126,7 @@ tape('request logging', (test) => {
     });
 
   });
+  test.end();
 
 });
 
@@ -148,6 +152,7 @@ tape('service disabled tests', (test) => {
     });
 
   });
+  test.end();
 
 });
 
@@ -564,6 +569,7 @@ tape('failure conditions tests', (test) => {
     });
 
   });
+  test.end();
 
 });
 
@@ -768,6 +774,7 @@ tape('success conditions tests', (test) => {
     });
 
   });
+  test.end();
 
 });
 
@@ -845,5 +852,5 @@ tape('callback-as-2nd-parameter tests', (test) => {
     });
 
   });
-
+  test.end();
 });


### PR DESCRIPTION
In a recent release, `tape` fixed a bug (https://github.com/substack/tape/issues/458) which ends up also being a major breaking change.

Essentially, any time tests are nested, both the nested and top level tests must call `end()`. This appears to have affected many of our repositories, as we heavily use nested tests.

Fixes https://github.com/pelias/microservice-wrapper/issues/33