### PR TITLE
Support HTTPS or HTTP service URLs

### DIFF
--- a/service.js
+++ b/service.js
@@ -1,6 +1,5 @@
-'use strict';
-
 const http = require('http');
+const https = require('https');
 const request = require('superagent');
 const _ = require('lodash');
 
@@ -49,8 +48,10 @@ module.exports = function setup(serviceConfig) {
 
   logger.info(`using ${serviceConfig.getName()} service at ${serviceConfig.getBaseUrl()}`);
 
+  const connection_library = serviceConfig.getBaseUrl().startsWith('https') ? https : http;
+
   // create one HTTP agent with keep alives enabled per service instance
-  const agent = new http.Agent({
+  const agent = new connection_library.Agent({
     keepAlive: true
   });
 


### PR DESCRIPTION
While the recommended configuration for Pelias has used HTTP communication between services, there are many valid reasons to put each service behind HTTPS.

Because of Node.js's interesting decision to have completely separate and incompatible `http` and `https` modules, this has not been a supported configuration out of the box.

However, adding this support is not difficult, and that's what's been done here. Both HTTP and HTTPS service URLs should work seamlessly now.

Fixes https://github.com/pelias/pelias/issues/839